### PR TITLE
{duplicate] Bump the version to 0.1.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ sql/first_last_agg--0.1.1.sql
 sql/first_last_agg--0.1.2.sql
 sql/first_last_agg--0.1.3.sql
 sql/first_last_agg--0.1.4.sql
+sql/first_last_agg--0.1.5.sql
 src/first_last_agg.o
 src/first_last_agg.so

--- a/META.json
+++ b/META.json
@@ -1,7 +1,7 @@
 {
    "name": "first_last_agg",
    "abstract": "Provides first() and last() aggregate functions.",
-   "version": "0.1.4",
+   "version": "0.1.5",
    "maintainer": [
       "Jan Urbański <wulczer@wulczer.org>"
    ],
@@ -18,7 +18,7 @@
       "first_last_agg": {
          "file": "sql/first_last_agg.sql",
          "docfile": "doc/first_last_agg.md",
-         "version": "0.1.4"
+         "version": "0.1.5"
       }
    },
    "resources": {

--- a/doc/first_last_agg.md
+++ b/doc/first_last_agg.md
@@ -1,4 +1,4 @@
-first-last-agg 0.1.4
+first-last-agg 0.1.5
 ====================
 
 Synopsis

--- a/first_last_agg.control
+++ b/first_last_agg.control
@@ -1,5 +1,5 @@
 # first_last_agg extension
 comment = 'first() and last() aggregate functions'
-default_version = '0.1.4'
+default_version = '0.1.5'
 module_pathname = '$libdir/first_last_agg'
 relocatable = true

--- a/sql/first_last_agg--0.1.4--0.1.5.sql
+++ b/sql/first_last_agg--0.1.4--0.1.5.sql
@@ -1,0 +1,30 @@
+/*
+ * Make aggregate functions parallel safe, starting with PG10.
+ */
+DO $$
+DECLARE version_num integer;
+BEGIN
+  SELECT current_setting('server_version_num') INTO STRICT version_num;
+  IF version_num > 90600 THEN
+    EXECUTE $E$  ALTER FUNCTION last_sfunc(anyelement, anyelement) PARALLEL SAFE   $E$;
+    EXECUTE $E$ ALTER FUNCTION first_sfunc(anyelement, anyelement) PARALLEL SAFE   $E$;
+
+    EXECUTE $E$ DROP AGGREGATE IF EXISTS first(anyelement) $E$;
+    EXECUTE $E$ CREATE AGGREGATE first(anyelement) (
+        SFUNC = first_sfunc,
+        STYPE = anyelement,
+        COMBINEFUNC = first_sfunc,
+        parallel = SAFE
+    ); $E$;
+
+    EXECUTE $E$ DROP AGGREGATE IF EXISTS last(anyelement) $E$;
+    EXECUTE $E$ CREATE AGGREGATE last(anyelement) (
+        SFUNC = last_sfunc,
+        STYPE = anyelement,
+        COMBINEFUNC = last_sfunc,
+        parallel = SAFE
+    ); $E$;
+  END IF;
+END;
+$$;
+


### PR DESCRIPTION
Adds an update script to set aggregate functions to parallel-safe.